### PR TITLE
Leave engine on, when exiting the car

### DIFF
--- a/client/systems/vehicles.mjs
+++ b/client/systems/vehicles.mjs
@@ -57,3 +57,22 @@ function disableSeatShuffle() {
         }
     }
 }
+
+// Disable turning engine off, after exiting (Holding F will still turn it off)
+alt.on('keyup', (key) => {
+    if (key === 'F'.charCodeAt(0)) {
+        const player = alt.Player.local.scriptID;
+
+        if (!native.isPedInAnyVehicle(player, undefined)) return;
+        let vehicle = native.getVehiclePedIsIn(player, undefined);
+
+        if (!native.getPedInVehicleSeat(vehicle, -1) === player) return;
+
+        let interval = alt.setInterval(() => {
+            if (vehicle && !alt.Player.local.vehicle) {
+                native.setVehicleEngineOn(vehicle, true, true, false);
+                alt.clearInterval(interval);
+            }
+        }, 100);
+    }
+});


### PR DESCRIPTION
This will keep the engine running, after you've exited the car.
If you're pressing F until you've left the car, it won't turn it back on.

To sum it up : 
- Short F = Engine will stay running
- Long F = Engine will turn off

### What are you comitting?

A clientside-script to leave the engine on

### Why are you comitting this?

Because I think it'll save some time

### What steps did you take to maintain a similar code style as the master branch

I nearly copied your style by checking the same and other files

### Anything else...
