### PR TITLE
add new Leave button to atm modal; remove conflicting a d w s key events

### DIFF
--- a/client/html/atm/app.js
+++ b/client/html/atm/app.js
@@ -89,6 +89,10 @@ class App extends Component {
         }
     }
 
+    leave() {
+        alt.emit('close');
+    }
+
     render() {
         return h(
             'div',
@@ -142,7 +146,8 @@ class App extends Component {
                         'div',
                         { class: 'center' },
                         h('button', { onclick: this.withdraw.bind(this) }, 'Withdraw'),
-                        h('button', { onclick: this.deposit.bind(this) }, 'Deposit')
+                        h('button', { onclick: this.deposit.bind(this) }, 'Deposit'),
+                        h('button', { onclick: this.leave.bind(this) }, 'Leave'),
                     )
                 )
             )
@@ -157,13 +162,3 @@ function ready() {
         alt.emit('atm:Ready');
     }
 }
-
-const keys = ['W'.charCodeAt(0), 'A'.charCodeAt(0), 'S'.charCodeAt(0), 'D'.charCodeAt(0)];
-
-window.addEventListener('keyup', e => {
-    if (keys.includes(e.keyCode)) {
-        if ('alt' in window) {
-            alt.emit('close');
-        }
-    }
-});


### PR DESCRIPTION
### What are you comitting?

Changing how you exit the ATM menu.   It adds an additional Leave button so that it's clear how to exit the ATM menu.

### Why are you comitting this?

I found it confusing otherwise.

### What steps did you take to maintain a similar code style as the master branch

Followed examples.

### Anything else...

I removed the mapping of W A S D keys because when using them, it /did/ close the atm menu, but it also unlocked my car.  Seems there is a conflict somewhere.  In any event, I found it easier to simply provide a Leave option on the menu.