### PR TITLE
Admin group system

### DIFF
--- a/server/cache/cache.mjs
+++ b/server/cache/cache.mjs
@@ -15,10 +15,11 @@ export function cacheName(name) {
     names.push(name);
 }
 
-export function cacheAccount(username, id, password) {
+export function cacheAccount(username, id, password, admingroup) {
     accounts[username] = {
         id,
-        password
+        password,
+        admingroup
     };
 }
 

--- a/server/commands/sandbox.mjs
+++ b/server/commands/sandbox.mjs
@@ -30,32 +30,33 @@ chat.registerCmd('addcash', (player, value) => {
     let data = value * 1;
     if (value > 600000) return;
     player.addCash(data);
-});
+}, 'admin');
 
 chat.registerCmd('wep', (player, hash) => {
     if (hash === undefined) {
         player.send(`Hash; such as: -270015777`);
         return;
     }
-    if (parseInt(hash) == NaN)
-        hash = alt.hash(hash);
+    let weapon = hash[0];
+    if (parseInt(weapon) == NaN)
+        weapon = alt.hash(weapon);
 
-    player.giveWeapon(hash[0], 9999, true);
-});
+    player.giveWeapon(weapon, 9999, true);
+}, 'admin');
 
 chat.registerCmd('face', player => {
     player.showFaceCustomizerDialogue(player.pos);
-});
+}, 'admin');
 
 chat.registerCmd('granola', player => {
     let itemTemplate = configurationItems.Items['GranolaBar'];
     player.addItem(itemTemplate, 5);
-});
+}, 'admin');
 
 chat.registerCmd('coffee', player => {
     let itemTemplate = configurationItems.Items['Coffee'];
     player.addItem(itemTemplate, 5);
-});
+}, 'admin');
 
 chat.registerCmd('additem', (player, arg) => {
     let itemTemplate = configurationItems.Items[`${arg[0]}`];
@@ -64,7 +65,7 @@ chat.registerCmd('additem', (player, arg) => {
         return;
     }
     player.addItem(itemTemplate, 1);
-});
+}, 'admin');
 
 chat.registerCmd('addveh', (player, arg) => {
     try {
@@ -101,7 +102,7 @@ chat.registerCmd('tpto', (player, arg) => {
     }
 
     player.pos = target.pos;
-});
+}, 'helper');
 
 chat.registerCmd('players', player => {
     alt.Player.all.forEach(t => {

--- a/server/commands/sandbox.mjs
+++ b/server/commands/sandbox.mjs
@@ -37,6 +37,8 @@ chat.registerCmd('wep', (player, hash) => {
         player.send(`Hash; such as: -270015777`);
         return;
     }
+    if (parseInt(hash) == NaN)
+        hash = alt.hash(hash);
 
     player.giveWeapon(hash[0], 9999, true);
 });

--- a/server/configuration/chat.mjs
+++ b/server/configuration/chat.mjs
@@ -2,5 +2,12 @@ export const ChatConfig = {
     maxChatRange: 25,
     maxMeRange: 15,
     maxDoRange: 15,
-    maxOocRange: 15
+    maxOocRange: 15,
+
+    adminGroups: [
+        'user',
+        'helper',
+        'admin',
+        'superadmin'
+    ]
 };

--- a/server/entities/entities.mjs
+++ b/server/entities/entities.mjs
@@ -17,6 +17,11 @@ export const Account = new orm.EntitySchema({
         },
         password: {
             type: 'varchar'
+        },
+        admingroup: {
+            type: 'varchar',
+            default: 'user',
+            nullable: false
         }
     }
 });

--- a/server/events/consoleCommand.mjs
+++ b/server/events/consoleCommand.mjs
@@ -1,11 +1,27 @@
 import * as alt from 'alt';
+import { ChatConfig } from '../configuration/chat.mjs';
+import * as cache from '../cache/cache.mjs';
 
-alt.on('consoleCommand', (command, argA) => {
+alt.on('consoleCommand', (command, argA, argB) => {
     if (command === 'kick') {
         const players = alt.getPlayersByName(argA);
         if (players.length === 1) {
             alt.log(`Kicking ${argA} - Roleplay Name ${players[0].username}`);
             players[0].kick();
+        }
+    } else if (command === 'setgroup') {
+        if (argB == null) return;
+        const players = alt.getPlayersByName(argA);
+        if (players.length === 1) {
+            if (ChatConfig.adminGroups.indexOf(argB) != -1) {
+                players[0].admingroup = argB;
+                let account = cache.getAccount(players[0].username);
+                if (account != null)
+                    account.admingroup = argB;
+                alt.log(`${players[0].username} - ${argA} Setted to group ${argB}`);
+            } else {
+                alt.log('That group doesn\'t exist');
+            }
         }
     }
 });

--- a/server/registration/login.mjs
+++ b/server/registration/login.mjs
@@ -46,6 +46,7 @@ export function existingAccount(player, username, password) {
     LoggedInPlayers.push(username);
 
     player.username = username;
+    player.admingroup = account.admingroup;
     player.showRegisterEventSuccess('Successful login! Please wait...');
     finishPlayerLogin(player, account.id);
     alt.log(`${player.name} has logged in.`);

--- a/server/registration/register.mjs
+++ b/server/registration/register.mjs
@@ -39,7 +39,7 @@ export function newAccount(player, username, password) {
 
     db.upsertData(playerAccDoc, 'Account', res => {
         // Add account to cache
-        cache.cacheAccount(res.username, res.id, passHashSalt);
+        cache.cacheAccount(res.username, res.id, passHashSalt, 'user');
 
         player.showRegisterEventSuccess('New account was registered successfully.');
 

--- a/server/startup.mjs
+++ b/server/startup.mjs
@@ -67,7 +67,6 @@ function cacheInformation() {
         if (data === undefined) return;
 
         for (let i = 0; i < data.length; i++) {
-            alt.log("Cached account " + data[i].username)
             cache.cacheAccount(data[i].username, data[i].id, data[i].password, data[i].admingroup);
         }
 

--- a/server/startup.mjs
+++ b/server/startup.mjs
@@ -63,11 +63,12 @@ alt.on('ConnectionComplete', () => {
 // Used to speed up the server dramatically.
 function cacheInformation() {
     // Passwords are encrypted.
-    db.selectData('Account', ['id', 'username', 'password'], data => {
+    db.selectData('Account', ['id', 'username', 'password', 'admingroup'], data => {
         if (data === undefined) return;
 
         for (let i = 0; i < data.length; i++) {
-            cache.cacheAccount(data[i].username, data[i].id, data[i].password);
+            alt.log("Cached account " + data[i].username)
+            cache.cacheAccount(data[i].username, data[i].id, data[i].password, data[i].admingroup);
         }
 
         console.log(`=====> Cached: ${data.length} Accounts`);


### PR DESCRIPTION
### What are you comitting?
Added one parameter to registerCmd but keeping compatibility with old way to specify admin group required to execute this command
Added Admin group system on users account

Admin groups automaticly inherits commands of lower groups (refer to chat configuration file)

### Why are you comitting this?

To remove the access to users of admin commands 

### What steps did you take to maintain a similar code style as the master branch

/

### Anything else...

player.send doesn't work BTW