### PR TITLE
handle null in chat messages; fixes unknown command message

### DIFF
--- a/client/html/chat/app.js
+++ b/client/html/chat/app.js
@@ -92,10 +92,12 @@ class App extends Component {
         };
 
         appendMessageSpecial = msg => {
+            if (!msg) return;
             this.appendMessage(msg);
         };
 
         appendMessage = msg => {
+            if (!msg) return;
             msg = colorify(msg);
             this.appendMessage({ message: msg });
         };

--- a/server/chat/chat.mjs
+++ b/server/chat/chat.mjs
@@ -31,7 +31,7 @@ export function routeMessage(player, msg) {
             if (callback) {
                 callback(player, args);
             } else {
-                player.send(player, `Unknown command /${cmd}`);
+                player.send(`Unknown command /${cmd}`);
             }
         }
         return;
@@ -39,7 +39,7 @@ export function routeMessage(player, msg) {
 
     // Regular chat messages.
     if (mutedPlayers.includes(player.name)) {
-        player.send(player, `You are muted at this time.`);
+        player.send('You are muted at this time.');
         return;
     }
 


### PR DESCRIPTION
### What are you comitting?

When typing an unknown command (such as `/asdoaisjdo` as chat input, the message is never routed which resulted in the colorify and appendMessage routines failing to handle the null.

Additionally, the `player.send` call was failing to indicate that the command was unknown.

### Why are you comitting this?

Because I care.

### What steps did you take to maintain a similar code style as the master branch

No new functionality, just simple fixes.

### Anything else...

This is fun.