### PR TITLE
Few sandbox command usability fixes

### DIFF
--- a/server/chat/chat.mjs
+++ b/server/chat/chat.mjs
@@ -24,7 +24,7 @@ export function routeMessage(player, msg) {
             alt.log('[CMD] ' + player.name + ': /' + msg);
 
             let args = msg.split(' ');
-            let cmd = args.shift();
+            let cmd = args.shift().toLowerCase();
 
             const callback = cmds[cmd];
 

--- a/server/commands/sandbox.mjs
+++ b/server/commands/sandbox.mjs
@@ -10,7 +10,7 @@ const sandboxhelp = [
     '/b, /me, /do',
     '/addveh (model)',
     '/addcash (amount)',
-    '/wep (hash)',
+    '/addwep (name)',
     '/face',
     '/granola, /coffee',
     '/tpto (rp-name)',
@@ -34,14 +34,14 @@ chat.registerCmd('addcash', (player, value) => {
     player.addCash(data);
 });
 
-chat.registerCmd('wep', (player, hash) => {
-    if (hash === undefined) {
-        player.send(`Hash; such as: -270015777`);
+chat.registerCmd('addwep', (player, arg) => {
+    if (arg === undefined || arg.length == 0) {
+        player.send('Usage: /addwep (name)');
         return;
     }
 
-    if (!addWeapon(player, parseInt(hash))) {
-        player.send(`Not a valid weapon hash. -270015777`);
+    if (!addWeapon(player, arg[0])) {
+        player.send('Weapon does not exist');
         return;
     }
 
@@ -63,6 +63,11 @@ chat.registerCmd('coffee', player => {
 });
 
 chat.registerCmd('additem', (player, arg) => {
+    if (arg == undefined || arg.length == 0) {
+        player.send('Usage: /additem (item)');
+        return;
+    }
+
     let itemTemplate = configurationItems.Items[`${arg[0]}`];
     if (itemTemplate === undefined) {
         player.send('Item does not exist');
@@ -72,6 +77,11 @@ chat.registerCmd('additem', (player, arg) => {
 });
 
 chat.registerCmd('addveh', (player, arg) => {
+    if (arg == undefined || arg.length == 0) {
+        player.send('Usage: /addveh (vehicle)');
+        return;
+    }
+
     try {
         player.addVehicle(arg[0], player.pos, new alt.Vector3(0, 0, 0));
     } catch (e) {
@@ -81,7 +91,7 @@ chat.registerCmd('addveh', (player, arg) => {
 
 chat.registerCmd('coord', (player, args) => {
     if (args.length <= 2) {
-        player.send('/coord (x, y, z)');
+        player.send('Usage: /coord (x, y, z)');
         return;
     }
 
@@ -93,8 +103,8 @@ chat.registerCmd('coord', (player, args) => {
 });
 
 chat.registerCmd('tpto', (player, arg) => {
-    if (arg === undefined) {
-        player.send('/tpto (roleplay_name)');
+    if (arg === undefined || arg.length == 0) {
+        player.send('Usage: /tpto (roleplay_name)');
         return;
     }
 

--- a/server/systems/inventory.mjs
+++ b/server/systems/inventory.mjs
@@ -241,10 +241,10 @@ export function updatePosition(player, newIndex, oldIndex) {
     player.swapItems(newIndex, oldIndex);
 }
 
-export function addWeapon(player, weaponHash) {
+export function addWeapon(player, weaponName) {
     let weapon;
     Object.keys(Weapons).forEach(key => {
-        if (Weapons[key] !== weaponHash) return;
+        if (key !== weaponName) return;
         weapon = {
             name: key,
             value: Weapons[key]


### PR DESCRIPTION
### What are you comitting?

Just a few usability fixes to the sandbox commands. 
Renamed /wep to /addwep to be consistent with other add commands.
/addwep now takes weapon name instead of hash
Commands are now case-insensitive.  (Eg. /addItem)

### Why are you comitting this?

My OCD kicked in. 

### What steps did you take to maintain a similar code style as the master branch

Followed existing code.

### Anything else...
