### PR TITLE
hold tab for context cursor

### DIFF
--- a/client/events/keybinds.mjs
+++ b/client/events/keybinds.mjs
@@ -59,7 +59,7 @@ let keybinds = {
         shiftModifier: true,
         func: panelsChat.toggleHide
     },
-    // Tab - Toggle Cursor
+    // Tab - Hold for Context Cursor
     9: {
         altModifier: false,
         shiftModifier: false,
@@ -89,6 +89,12 @@ function loadInterval(key) {
 function keyup(key) {
     if (key === 16) shiftModified = false;
     if (key === 18) altModified = false;
+
+    // Release TAB to exit Context Cursor
+    if (key === 9) {
+        keybinds[key].func();
+        return;
+    }
 
     if (!alt.Player.local.getMeta('loggedin')) return;
     if (alt.Player.local.getMeta('chat')) return;
@@ -125,4 +131,7 @@ function keyup(key) {
 function keydown(key) {
     if (key === 16) shiftModified = true;
     if (key === 18) altModified = true;
+
+    // Hold TAB for Context Cursor
+    if (key === 9) keybinds[key].func();
 }

--- a/client/html/chat/app.js
+++ b/client/html/chat/app.js
@@ -75,7 +75,7 @@ class App extends Component {
                     style: 'color: rgba(255, 255, 255, 1) !important;'
                 },
                 {
-                    message: 'Press TAB to use context cursor.',
+                    message: 'Hold TAB to use context cursor.',
                     style: 'color: rgba(255, 255, 255, 1) !important;'
                 }
             ],


### PR DESCRIPTION
### What are you comitting?

A quick change to how the context menu works.  Instead of having to hit TAB to toggle the context menu, you now hold TAB to use it.  Releasing TAB will remove it.


### Why are you comitting this?

It was somewhat annoying to have to toggle back out of the context menu.

### What steps did you take to maintain a similar code style as the master branch

Followed existing style.   If it looks like we will have a number of "holding" keys vs "toggle" keys, it might make sense to refactor keybinds.mjs a bit to allow for these.  For now, the TAB key (code 9) is the first.

### Anything else...

