### PR TITLE
Only set context menu interval if one doesn't already exist

### DIFF
--- a/client/systems/context.mjs
+++ b/client/systems/context.mjs
@@ -177,7 +177,9 @@ let interval;
 
 export function showContext() {
     if (alt.Player.local.getMeta('viewOpen')) return;
-    interval = alt.setInterval(useMenu, 0);
+    if (!interval) {
+        interval = alt.setInterval(useMenu, 0);
+    }
 }
 
 export function hideContext() {


### PR DESCRIPTION
### What are you comitting?

Quick fix to avoid setting context menu interval is one already exists.

### Why are you comitting this?

Discovered some weirdness when interacting with an object where the context menu does not close after using an object (such as the ATM).    

To avoid creating additional intervals while in that state, this change prevents that.

### What steps did you take to maintain a similar code style as the master branch

..

### Anything else...
