### PR TITLE
hit ESC to close help view

### DIFF
--- a/client/events/keybinds.mjs
+++ b/client/events/keybinds.mjs
@@ -70,7 +70,7 @@ let keybinds = {
     112: {
         altModifier: false,
         shiftModifier: false,
-        onKeyUp: panelsHelp.toggleHelp
+        onKeyUp: panelsHelp.showHelp
     }
 };
 

--- a/client/html/help/app.js
+++ b/client/html/help/app.js
@@ -53,3 +53,15 @@ class App extends Component {
 }
 
 render(h(App), document.querySelector('#render'));
+
+document.addEventListener('keyup', key => {
+    if (key.key === 'Escape') {
+        alt.emit('help:Exit');
+    }
+
+    // Closing help view with F1 does not work.
+    // Use ESC instead.
+    //if (key.keyCode === 112) {
+    //    alt.emit('help:Exit');
+    //}
+});

--- a/client/panels/help.mjs
+++ b/client/panels/help.mjs
@@ -7,14 +7,22 @@ const url = 'http://resource/client/html/help/index.html';
 let webview;
 
 // Show the help dialogue
-export function toggleHelp() {
+export function showHelp() {
     if (!webview) {
         webview = new View();
-        webview.open(url, false);
-    } else {
-        webview.close();
-        webview = undefined;
     }
 
+    if (alt.Player.local.getMeta('viewOpen')) return;
+
+    // Ideally killControls would be set to false here
+    // but doing so prevents us from closing the view
+    // for some reason.
+    webview.open(url, true);
+    webview.on('help:Exit', exit);
 }
 
+function exit() {
+    console.log('exiting...');
+    webview.close();
+    webview = undefined;
+}

--- a/client/systems/context.mjs
+++ b/client/systems/context.mjs
@@ -201,7 +201,7 @@ function useMenu() {
         if (interval) {
             alt.clearInterval(interval);
             interval = undefined;
-            urrentContext = undefined;
+            currentContext = undefined;
             rayCastInfo = undefined;
         }
         return;


### PR DESCRIPTION
### What are you comitting?

Hit ESC to close help view.

### Why are you comitting this?

Fixing an issue where help view could not be closed.   I wasn't able to attach `keyup` event listener to F1 for some reason, so used ESC instead and had to use `killControls = true` for the view.

Seems there are some issues trying to bind events when `killControls` is set to false.  

### What steps did you take to maintain a similar code style as the master branch

..

### Anything else...

I'm thinking maybe a better approach for the help system is for it to work similar to the chat.  Instead of using a view, we could just overlay a hidden HTML div that can be toggled easily with a keybind.  
