### PR TITLE
draw text for player actions

### DIFF
--- a/client/utility/text.mjs
+++ b/client/utility/text.mjs
@@ -3,6 +3,30 @@ import * as native from 'natives';
 
 alt.log('Loaded: client->utility->text.mjs');
 
+alt.onServer('text:playerAction', (player, msg) => {
+    const interval = alt.setInterval(() => {
+        alt.nextTick(() => {
+            drawText3d(
+                `* ${msg} *`,
+                player.pos.x,
+                player.pos.y,
+                player.pos.z + 0.4,
+                0.4,
+                4,
+                255,
+                255,
+                255,
+                255,
+                true,
+                false
+            );
+        });
+    }, 0);
+    alt.setTimeout(() => {
+        alt.clearInterval(interval);
+    }, 5000);
+});
+
 alt.onServer('text:Animated', (text, duration) => {
     let pos = alt.Player.local.pos;
     let alpha = 255;

--- a/server/commands/roleplay.mjs
+++ b/server/commands/roleplay.mjs
@@ -14,10 +14,11 @@ chat.registerCmd('me', (player, args) => {
         return;
     }
 
+    let msg = args.join(' ');
     let inRange = vector.getPlayersInRange(player.pos, ChatConfig.maxMeRange);
-
     inRange.forEach(target => {
-        target.send(`{c5a5de}${player.data.name.replace('_', ' ')} ${args.join(' ')}`);
+        target.send(`{c5a5de}${player.data.name.replace('_', ' ')} ${msg}`);
+        alt.emitClient(target, 'text:playerAction', player, msg);
     });
 });
 
@@ -32,11 +33,11 @@ chat.registerCmd('do', (player, args) => {
         return;
     }
 
+    let msg = args.join(' ');
     let inRange = vector.getPlayersInRange(player.pos, ChatConfig.maxDoRange);
     inRange.forEach(target => {
-        target.send(
-            `{c5a5de}* (( ${player.data.name.replace('_', ' ')} )) ${args.join(' ')}`
-        );
+        target.send(`{c5a5de}* (( ${player.data.name.replace('_', ' ')} )) ${msg}`);
+        alt.emitClient(target, 'text:playerAction', player, msg);
     });
 });
 
@@ -71,34 +72,30 @@ chat.registerCmd('b', (player, args) => {
 
 chat.registerCmd('flipcoin', player => {
     const headsOrTails = Math.floor(Math.random() * 2) ? 'heads' : 'tails';
+    const msg = `Flips a coin and it lands on ${headsOrTails}`
     let inRange = vector.getPlayersInRange(player.pos, ChatConfig.maxOocRange);
     inRange.forEach(target => {
-        target.send(
-            `{c5a5de}* (( ${player.data.name.replace(
-                '_',
-                ' '
-            )} )) Flips a coin and it lands on ${headsOrTails}`
-        );
+        target.send(`{c5a5de}* (( ${player.data.name.replace('_', ' ')} )) ` + msg);
+        alt.emitClient(target, 'text:playerAction', player, msg);
     });
 });
 
 chat.registerCmd('sf', player => {
     const sOrF = Math.floor(Math.random() * 2) ? 'succeed' : 'fail';
+    const msg = `${sOrF}`
     let inRange = vector.getPlayersInRange(player.pos, ChatConfig.maxOocRange);
     inRange.forEach(target => {
-        target.send(`{c5a5de}* (( ${player.data.name.replace('_', ' ')} )) ${sOrF}`);
+        target.send(`{c5a5de}* (( ${player.data.name.replace('_', ' ')} )) ` + msg);
+        alt.emitClient(target, 'text:playerAction', player, msg);
     });
 });
 
 chat.registerCmd('d20', player => {
     const d20 = Math.floor(Math.random() * 20) + 1;
+    const msg = `Rolls a dice and it lands on ${d20}`
     let inRange = vector.getPlayersInRange(player.pos, ChatConfig.maxOocRange);
     inRange.forEach(target => {
-        target.send(
-            `{c5a5de}* (( ${player.data.name.replace(
-                '_',
-                ' '
-            )} )) Rolls a dice and it lands on ${d20}`
-        );
+        target.send(`{c5a5de}* (( ${player.data.name.replace('_', ' ')} )) ` + msg);
+        alt.emitClient(target, 'text:playerAction', player, msg);
     });
 });


### PR DESCRIPTION

### What are you comitting?

Player actions such as (`/me`, `/do`, etc) are now visible as native text on the player for 5 seconds.

### Why are you comitting this?

Few reasons:

* Improves the game experience when multiple players are emoting and performing actions.
* The actions are also shown in the chat (with the username) -- I didn't want to remove this (need to get Stuyk's thoughts on it)
* Having the action display directly on the player helps with anonymity as well, so you can perform actions (* tries to escape, etc *) without revealing your name in the chat.

### What steps did you take to maintain a similar code style as the master branch

Followed existing code patterns.

### Anything else...

Addressed the other commands I noticed in there (`/sf`, `/flipcoin`, etc) to work the same way.  


![alt_V Multiplayer 10_12_2019 4_22_01 PM](https://user-images.githubusercontent.com/7429/66707369-5a7cd900-ed0d-11e9-870d-52498fa3696a.png)