### PR TITLE
Fix installer to preserve a changed server.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-terms-and-conditions.json
+resources/*
+!resources/orp/*
 resources/orp/server/configuration/database.json
 node_modules/
 modules/

--- a/install.js
+++ b/install.js
@@ -102,7 +102,6 @@ async function question(question) {
 }
 
 async function downloadAll(urls) {
-    console.log(`Downloading Latest alt:V Server Files.`);
     for (let i = 0; i < urls.length; i++) {
         console.log(urls[i].url);
         await download(urls[i].url, urls[i].destination).catch(err => {
@@ -200,16 +199,8 @@ async function startup() {
     } else {
         console.log('\r\nSkipping already configured DB setup.');
     }
-
-    // Copy server.cfg
-    const serverCfgFile = path.join(__dirname, '/server.cfg');
-    if (!fs.existsSync(serverCfgFile)) {
-        fs.copyFile(serverCfgFile, serverCfgFile+'.example'), (err) => {
-            if (err) throw err;
-            console.log('server.cfg.example was copied to server.cfg');
-        }
-    }
-            
+        
+    console.log(`Downloading Latest alt:V Server Files.`);
     const q6 = '\r\nWhich alt:V Branch? 0: Stable, 1: Beta\r\n';
     res = await question(q6);
 
@@ -231,6 +222,15 @@ async function startup() {
         downloadAll(windowsURLS);
     } else {
         downloadAll(linuxURLS);
+    }
+
+    // Copy server.cfg
+    const serverCfgFile = path.join(__dirname, '/server.cfg');
+    if (!fs.existsSync(serverCfgFile)) {
+        fs.copyFile(serverCfgFile + '.example', serverCfgFile, (err) => {
+            if (err) throw err;
+            console.log('server.cfg.example was copied to server.cfg');
+        });
     }
 }
 

--- a/install.js
+++ b/install.js
@@ -201,6 +201,15 @@ async function startup() {
         console.log('\r\nSkipping already configured DB setup.');
     }
 
+    // Copy server.cfg
+    const serverCfgFile = path.join(__dirname, '/server.cfg');
+    if (!fs.existsSync(serverCfgFile)) {
+        fs.copyFile(serverCfgFile, serverCfgFile+'.example'), (err) => {
+            if (err) throw err;
+            console.log('server.cfg.example was copied to server.cfg');
+        }
+    }
+            
     const q6 = '\r\nWhich alt:V Branch? 0: Stable, 1: Beta\r\n';
     res = await question(q6);
 

--- a/server.cfg.example
+++ b/server.cfg.example
@@ -2,7 +2,7 @@ name: 'alt:V - ORP'
 host: 0.0.0.0
 port: 7788
 players: 64
-announce: true
+announce: false
 gamemode: ORP
 website: twitch.tv/stuyksoft
 language: lang-here
@@ -10,5 +10,5 @@ description: ''
 modules: [ node-module ]
 resources: [ orp ]
 #token:
-debug: 'true',
+debug: true
 streamingDistance: 300


### PR DESCRIPTION
### What are you comitting?

After configuring server.cfg,  git is tracking these changes because they are checked in.   To make this work properly with .gitignore, these files shouldn't be checked in.

This changes the installer to use server.cfg.example as the template for server.cfg, and will write it out if it doesn't exist.

### Why are you comitting this?

Ease of use.

### What steps did you take to maintain a similar code style as the master branch



### Anything else...
