### PR TITLE
adds /anim to sandbox commands

### DIFF
--- a/resources/orp/server/commands/sandbox.mjs
+++ b/resources/orp/server/commands/sandbox.mjs
@@ -10,6 +10,7 @@ import { generateHash } from '../utility/encryption.mjs';
 const sandboxhelp = [
     //
     '/b, /me, /do',
+    '/anim (dict) (name) (duration) (flag)',
     '/addveh (model)',
     '/addcash (amount)',
     '/addwep (name)',
@@ -30,6 +31,17 @@ chat.registerCmd('help', player => {
     sandboxhelp.forEach(helper => {
         player.send(`${helper}`);
     });
+});
+
+chat.registerCmd('anim', (player, args) => {
+    if (args === undefined || args.length < 2) {
+        player.send('Usage: /anim (dict) (name) (duration) (flag)');
+        return;
+    }
+
+    const dur = args[2] ? args[2] : 2500;
+    const flag = args[3] ? args[3] : 33;
+    player.playAnimation(args[0], args[1], dur, flag);
 });
 
 chat.registerCmd('addcash', (player, value) => {


### PR DESCRIPTION
### What are you comitting?

quick change that adds `/anim` command to sandbox.

Eg. `/anim amb@medic@standing@kneel@idle_a idle_a`

### Why are you comitting this?

Makes it easier to test different animations.

### What steps did you take to maintain a similar code style as the master branch

n/a

### Anything else...
